### PR TITLE
chore: add node service handler

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -825,7 +825,7 @@ func (app *BitsongApp) RegisterTendermintService(clientCtx client.Context) {
 }
 
 // RegisterNodeService implements the Application.RegisterNodeService method.
-func (app *BitsongApp) RegisterNodeService(clientCtx client.Context, cfg config.Config) {
+func (app *BitsongApp) RegisterNodeService(clientCtx client.Context) {
 	nodeservice.RegisterNodeService(clientCtx, app.BaseApp.GRPCQueryRouter())
 }
 

--- a/app/app.go
+++ b/app/app.go
@@ -57,6 +57,7 @@ import (
 	fantokenclient "github.com/bitsongofficial/go-bitsong/x/fantoken/client"
 	merkledropclient "github.com/bitsongofficial/go-bitsong/x/merkledrop/client"
 	"github.com/cosmos/cosmos-sdk/baseapp"
+	nodeservice "github.com/cosmos/cosmos-sdk/client/grpc/node"
 	"github.com/cosmos/cosmos-sdk/client/grpc/tmservice"
 	"github.com/cosmos/cosmos-sdk/client/rpc"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -800,6 +801,8 @@ func (app *BitsongApp) RegisterAPIRoutes(apiSvr *api.Server, apiConfig config.AP
 	authtx.RegisterGRPCGatewayRoutes(clientCtx, apiSvr.GRPCGatewayRouter)
 	// Register new tendermint queries routes from grpc-gateway.
 	tmservice.RegisterGRPCGatewayRoutes(clientCtx, apiSvr.GRPCGatewayRouter)
+	// Register new tendermint queries routes from grpc-gateway.
+	nodeservice.RegisterGRPCGatewayRoutes(clientCtx, apiSvr.GRPCGatewayRouter)
 
 	// Register legacy and grpc-gateway routes for all modules.
 	ModuleBasics.RegisterRESTRoutes(clientCtx, apiSvr.Router)
@@ -819,6 +822,11 @@ func (app *BitsongApp) RegisterTxService(clientCtx client.Context) {
 // RegisterTendermintService implements the Application.RegisterTendermintService method.
 func (app *BitsongApp) RegisterTendermintService(clientCtx client.Context) {
 	tmservice.RegisterTendermintService(app.BaseApp.GRPCQueryRouter(), clientCtx, app.interfaceRegistry)
+}
+
+// RegisterNodeService implements the Application.RegisterNodeService method.
+func (app *BitsongApp) RegisterNodeService(clientCtx client.Context, cfg config.Config) {
+	nodeservice.RegisterNodeService(clientCtx, app.BaseApp.GRPCQueryRouter())
 }
 
 func (app *BitsongApp) setupUpgradeStoreLoaders() {


### PR DESCRIPTION
Adds the `/cosmos/base/node/v1beta1/config` endpoint, which returns `minimal_gas_prices` metric.
This is handy for Hermes as it queries this endpoint for healthcheck.

You can see the demo here: https://api.bitsong.quokkastake.io/cosmos/base/node/v1beta1/config, it returns an empty string here as my node does not have minimum_gas_prices set.

Would be nice if that could be pushed as 0.15.1 or something.